### PR TITLE
Fix github link

### DIFF
--- a/IIPS/iip-009.md
+++ b/IIPS/iip-009.md
@@ -49,7 +49,7 @@ Changing Snapshot is simple to do, and many prominant protocols have done this t
 
 ### Technical Specification
 <!--The technical specification should outline the public API of the changes proposed. That is, changes to any of the interfaces Index Coop currently exposes or the creations of new ones.-->
-The modifications of the Snapshot Space can be viewed here: https://github.com/ncitron/snapshot-spaces/blob/master/spaces/index/index.json.
+The modifications of the Snapshot Space can be viewed here: https://github.com/ncitron/snapshot-spaces/blob/index/spaces/index/index.json.
 
 ## Copyright
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
I had to do some rearranging with my GitHub forks. This will update the IIP to point to the correct version of the strategy change. We should probably also update this link in the IIP being voted on in the forums.